### PR TITLE
build(node): bump from 14.x to 16.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm publish
         env:


### PR DESCRIPTION
closes [AB#4318](https://dev.azure.com/rbheBoards/c7d9d701-a85f-45ff-91f6-26c56ff2c4de/_workitems/edit/4318)

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->
Upgrade from Node 14.x to new LTS 16.x

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )
