### PR TITLE
fix: uninitialized variables (fileReaderAcc, fileReaderInUse) in AMTRedirector

### DIFF
--- a/src/core/AMTRedirector.ts
+++ b/src/core/AMTRedirector.ts
@@ -54,6 +54,8 @@ export class AMTRedirector implements ICommunicator {
 
   constructor (logger: ILogger, protocol: number, fr: FileReader, host: string, port: number, user: string, pass: string, tls: number, tls1only: number, authToken: string, server?: string) {
     this.fileReader = fr
+    this.fileReaderInUse = false
+    this.fileReaderAcc = []
     this.randomNonceChars = 'abcdef0123456789'
     this.host = host
     this.port = port
@@ -105,7 +107,7 @@ export class AMTRedirector implements ICommunicator {
    * gets Ws Location and starts a websocket for listening
    * @param c is base type for WebSocket
    */
-  start<T> (c: new(path: string, auth: string) => T): any { // Using this generic signature allows us to pass the WebSocket type from unit tests or in producion from a web browser
+  start<T> (c: new(path: string, auth: string) => T): any { // Using this generic signature allows us to pass the WebSocket type from unit tests or in production from a web browser
     this.connectState = 0
     // let ws = new c(this.getWsLocation()) // using create function c invokes the constructor WebSocket()
     // eslint-disable-next-line new-cap


### PR DESCRIPTION
## PR Checklist

- [ ] Unit Tests have been added for new changes - no, see below
- [ ] All commented code has been removed - no, see below

## What are you changing?

fileReaderAcc and fileReaderInUse were uninitialized.  fileReaderAcc being undefined caused exceptions if an incoming message was binary.

## Anything the reviewer should know when reviewing this PR?

Note that outgoing messages _are_ binary.  Incoming messages should be binary too - they currently display as strings in the browser developer tools which give no option to display in hex.  This makes debugging difficult.

Pre-existing commented code has been left untouched.

There are currently no unit tests that exercise this code i.e. it's never been used.  The Blob object isn't supported in the test framework (attempts to create a Blob result in an empty object; suggestions such as using blob-polyfill don't help and importing Blob from buffer results in errors calling FileReader.readAsBinaryString).

Also fixed a distracting typo in a comment.
