### PR TITLE
fix(build): restore dist/core/package.json subpath shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ out/
 
 **/*.xml
 dist/**
+!dist/core/
+!dist/core/package.json

--- a/dist/core/package.json
+++ b/dist/core/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ui-toolkit/core",
+  "main": "../bundles/core.bundle.js",
+  "typings": "./index.d.ts",
+  "module": "../bundles/core.bundle.js",
+  "es2015": "../bundles/core.bundle.js",
+  "fesm2015": "../bundles/core.bundle.js",
+  "esm2015": "../bundles/core.bundle.js"
+}


### PR DESCRIPTION
## Summary
- Restores `dist/core/package.json`, the hand-authored subpath shim that maps `@device-management-toolkit/ui-toolkit/core` to `bundles/core.bundle.js`.
- The previous PR to untrack `dist/` deleted this file along with everything else. `npm run build-ext` does not regenerate it, so the published 3.3.13 tarball shipped without it and consumers (ui-toolkit-angular CI included) can no longer resolve the `/core` subpath.
- Exempts only this single file from `dist/**` in `.gitignore` so the rest of dist remains an untracked build artifact.

## Test plan
- [ ] Verify CI publishes 3.3.14 with `core/package.json` present (`npm pack` of the published tarball should contain `package/core/package.json`).
- [ ] After 3.3.14 is published, ui-toolkit-angular CI green (test-ci resolves `@device-management-toolkit/ui-toolkit/core`).