### PR TITLE
ci: Enable Semgrep and Zizmor scans

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+
+name: Semgrep Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+jobs:
+  semgrep:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep@sha256:14e073f6417e5d2d0797aa13f26d569270b86fac9d52052d2358c985f1a4e9f0  # v1.124.0
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run Semgrep scan
+        uses: open-edge-platform/orch-ci/.github/actions/security/semgrep@8e869384de7ed5f98941c59c2e4ac73eb09862fb  # 2026.1.3
+        with:
+          scan-scope: all
+          severity: "HIGH"
+          output-format: "text"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+
+name: Zizmor Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    permissions:
+      contents: read
+      security-events: write
+
+    runs-on: ubuntu-latest
+
+    env:
+      ZIZMOR_VERSION: 1.20.0
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      - name: Run Zizmor
+        run: |
+          uvx zizmor=="$ZIZMOR_VERSION" \
+            --format sarif \
+            .github \
+            > zizmor_scan_report.sarif
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: zizmor_scan_report.sarif
+
+      - name: Upload Zizmor report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zizmor-results
+          path: zizmor_scan_report.sarif
+          retention-days: 7


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to automate security scanning in the CI pipeline. The first workflow integrates Semgrep for code scanning, and the second introduces Zizmor for additional security analysis, both targeting the `main` branch on pushes and pull requests.

Jira: https://jira.devtools.intel.com/browse/NEXUIE-132281 

**Security scanning workflow additions:**

*Semgrep integration:*
- Added `.github/workflows/semgrep.yml` to run Semgrep scans automatically on pushes, pull requests, and manual triggers, using a hardened runner and a containerized Semgrep image.

*Zizmor integration:*
- Added `.github/workflows/zizmor.yml` to run Zizmor scans, upload results in SARIF format to GitHub Security, and store the scan report as a build artifact. This workflow also uses a hardened runner and installs dependencies with `uv`.
