### PR TITLE
ci: Fixed some code-scanning warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ROSIE_TOKEN }}
       - name: Publish to @device-management-toolkit
         if: steps.semantic.outputs.new_release_published == 'true'
+        env:
+          NEW_RELEASE_VERSION: ${{ steps.semantic.outputs.new_release_version }}
         run: |
-          echo "Publishing @device-management-toolkit/ui-toolkit@${{ steps.semantic.outputs.new_release_version }}"
+          echo "Publishing @device-management-toolkit/ui-toolkit@${NEW_RELEASE_VERSION}"
 
           sed -i 's/"@open-amt-cloud-toolkit\/ui-toolkit"/"@device-management-toolkit\/ui-toolkit"/' dist/package.json
-          sed -i 's/"version": "[^"]*"/"version": "${{ steps.semantic.outputs.new_release_version }}"/' dist/package.json
+          sed -i 's/"version": "[^"]*"/"version": "${NEW_RELEASE_VERSION}"/' dist/package.json
           cd dist
           npm publish

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: .github/commitlint.config.cjs


### PR DESCRIPTION
This pull request introduces several improvements to the CI/CD workflow configuration, focusing on enhancing security and maintainability. The most significant changes include disabling credential persistence during repository checkout in workflows, standardizing environment variable usage in the release process, and configuring a cooldown period for dependency updates.

**CI/CD Security Improvements:**
* Updated all uses of `actions/checkout` in workflow files (`codeql-analysis.yml`, `node.js.yml`, `semantic.yml`) to set `persist-credentials: false`, reducing the risk of leaking repository credentials to subsequent workflow steps. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R55-R56) [[2]](diffhunk://#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eR28-R29) [[3]](diffhunk://#diff-b39334e9e1b3208c63fbd06a0b9652fb6fba2a0afbbd146d723f0c7688b3de78R21)

**Release Process Enhancements:**
* Modified the release workflow to use an explicit `NEW_RELEASE_VERSION` environment variable for versioning and publishing, improving clarity and reducing duplication in shell commands.

**Dependency Management:**
* Added a `cooldown` period of 7 days to Dependabot configuration for both npm and GitHub Actions updates, limiting the frequency of pull requests and reducing notification noise.
